### PR TITLE
[feat] Toggle shortcut for lua script

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ If the issue remains unresolved, please create a new issue.
 
 ## Usage
 
+- Press `i` in MPV to toggle the skipping of the OP/ED
+##
+
+
 ```sh
 ani-skip -h
 ```

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ If the issue remains unresolved, please create a new issue.
 
 ## Usage
 
-- Press `i` in MPV to toggle the skipping of the OP/ED
+- Press **`i`** in MPV to toggle the skipping of the OP/ED
+> To configure this key, open `mpv/input.conf` and add the line `b script-binding skip_enable`,replace `b` with key of your choosing.\
+ Note: Typing `B` in the config requires pressing **`shift`** + **`b`** in MPV. \
+(`i` will still work, unless the remaped in the input config.)
 ##
-
 
 ```sh
 ani-skip -h

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If the issue remains unresolved, please create a new issue.
 - Press **`i`** in MPV to toggle the skipping of the OP/ED
 > To configure this key, open `mpv/input.conf` and add the line `b script-binding skip_enable`,replace `b` with key of your choosing.\
  Note: Typing `B` in the config requires pressing **`shift`** + **`b`** in MPV. \
-(`i` will still work, unless the remaped in the input config.)
+(`i` will still work, unless remaped in the input config.)
 ##
 
 ```sh

--- a/skip.lua
+++ b/skip.lua
@@ -14,7 +14,7 @@ mpv_options.read_options(options, "skip") --reading script-opts data
 local function skip()
     local current_time = mp.get_property_number("time-pos")
 
-    if not enabled then  
+    if not enabled then
         return
     end
 

--- a/skip.lua
+++ b/skip.lua
@@ -13,15 +13,15 @@ mpv_options.read_options(options, "skip") --reading script-opts data
 -- Main function to check and skip if within the defined section
 local function skip()
     local current_time = mp.get_property_number("time-pos")
-    
+
     if not enabled then  
         return
     end
-    
+
     if not current_time then
         return
     end
-    
+
     -- Check for opening sequence
     if current_time >= options.op_start and current_time < options.op_end then
         mp.set_property_number("time-pos", options.op_end)

--- a/skip.lua
+++ b/skip.lua
@@ -2,6 +2,9 @@
 local mpv = require('mp')
 local mpv_options = require("mp.options")
 
+--Default states
+local enabled = true
+local keybind = "i"
 local options = { -- setting default options
     op_start = 0, op_end = 0, ed_start = 0, ed_end = 0,
 }
@@ -11,10 +14,14 @@ mpv_options.read_options(options, "skip") --reading script-opts data
 local function skip()
     local current_time = mp.get_property_number("time-pos")
     
+    if not enabled then  
+        return
+    end
+    
     if not current_time then
         return
     end
-
+    
     -- Check for opening sequence
     if current_time >= options.op_start and current_time < options.op_end then
         mp.set_property_number("time-pos", options.op_end)
@@ -26,5 +33,11 @@ local function skip()
     end
 end
 
+local function enabled_state()
+    enabled = not enabled
+    mp.osd_message("Ani-Skip is " .. (enabled and "enabled" or "disabled"), 1)
+end  
+
 -- Bind the function to be called whenever the time position is changed
 mp.observe_property("time-pos", "number", skip)
+mp.add_key_binding("i", "skipping", enabled_state)

--- a/skip.lua
+++ b/skip.lua
@@ -40,4 +40,4 @@ end
 
 -- Bind the function to be called whenever the time position is changed
 mp.observe_property("time-pos", "number", skip)
-mp.add_key_binding("i", "skipping", enabled_state)
+mp.add_key_binding(keybind, "skip_enable", enabled_state)


### PR DESCRIPTION
Adds a shortcut in to the lua script so you can toggle the script by pressing `i` for the rare cases where the api times are not quite correct or QoL when binging in ani-cli when using `-r` to for example watch the opening once.

Generally if they are off its only by like half a sentence from expirience, so not a totally necesary feature. 

I also added it in to the Readme.md, its fine if you want to have it differently though.

Tested it extensively this time, so there shouldnt be any issues.