### PR TITLE
feat: add AllAnime source and regex filter for MAL ID resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,47 +48,73 @@ ani-skip -h
 
     Options:
       -q, --query
-        Anime Title or MyAnimeList ID
+        Search query for anime title
+      -i, --id
+        Direct source ID (MyAnimeList or AllAnime ID)
       -e, --episode
         Specify the episode number
+      -s, --source
+        Source for ID/query resolution (myanimelist, allanime). Default: myanimelist
+      -f, --filter
+        Regex to filter search results for disambiguation (used with -q)
       -V, --version
         Show the version of the script
       -h, --help
         Show this help message and exit
       -U, --update
         Update the script
+
+    Either -q or -i is required.
+
     Some example usages:
-      ani-skip -q "Solo Leveling" # Returns MyAnimeList ID
-      ani-skip -q "Solo Leveling" -e 3 # Returns MPV skip flag
-      ani-skip -q 52299 -e 5 # Returns MPV skip flag
+      ani-skip -i 52299 -e 5 # MAL ID directly
+      ani-skip -i "ReooPAxPMsHM4KPMY" -s allanime -e 12 # AllAnime ID directly
+      ani-skip -q "Solo Leveling" -e 3 # Search MAL (default)
+      ani-skip -q "one piece" -s allanime -f "^1P$" -e 12 # Search AllAnime with filter
+      ani-skip -q "Solo Leveling" -s allanime -f "Season 2" -e 1 # Season disambiguation
 ```
 
-- Build MPV skip options directly using anime's title
-  ```sh
-  ani-skip --query "Black Clover (170 episodes)" --episode 10
-  ```
-  ```
-  --chapters-file=/tmp/tempfile --script-opts=skip-op_start=140.153,skip-op_end=230.153,skip-ed_start=1301.824,skip-ed_end=1431
-  ```
-  > `script-opts` with the `script` flag is produced by ani-skip when metadata for a specific anime's skip times exists in the database. It's important to append these flags at the end due to certain mpv nuances.
+### Search MAL (default, backwards compatible)
 
-- Fetch `MyAnimeList` ID
-  ```sh
-  ani-skip -q "Solo Leveling"
-  ```
-  ```
-  52299
-  ```
-  > Persisting it will help building flags quickly when requesting the same anime for skip times.
+```sh
+ani-skip -q "Solo Leveling" -e 3
+```
+```
+--chapters-file=/tmp/tempfile --script-opts=skip-op_start=130.531,skip-op_end=220.531,skip-ed_start=1326.58,skip-ed_end=1416.58
+```
 
-- Build MPV skip options directly using `MyAnimeList` ID
-  ```sh
-  ani-skip -q 52299 -e 2
-  ```
-  ```
-  --chapters-file=/tmp/tempfile --script-opts=skip-op_start=130.531,skip-op_end=220.531,skip-ed_start=1326.58,skip-ed_end=1416.58
-  ```
-  > Use the stored or persisted MAL ID to expedite the process of fetching skip times.
+### Search AllAnime
+
+AllAnime stores `malId` for each show, so querying it directly avoids the title mismatch issues that occur when anime have non-standard display names (e.g. "1P" for One Piece).
+
+```sh
+ani-skip -q "one piece" -s allanime -f "^1P$" -e 12
+```
+
+Use `-f` with a regex to disambiguate results (exact match, season selection, etc).
+
+### Direct ID input
+
+Pass a MAL or AllAnime ID directly to skip the search step entirely. This is the ideal path for [ani-cli](https://github.com/pystardust/ani-cli) integration since it already has the AllAnime `_id`.
+
+```sh
+# AllAnime ID
+ani-skip -i "ReooPAxPMsHM4KPMY" -s allanime -e 12
+
+# MAL ID
+ani-skip -i 52299 -e 5
+```
+
+### Fetch MAL ID only (no episode)
+
+Omit `-e` to just resolve and print the MAL ID.
+
+```sh
+ani-skip -q "Solo Leveling"
+```
+```
+52299
+```
 
 
 ## Install
@@ -126,7 +152,8 @@ ani-skip -h
 ## Checklist
 
 - [x] MPV support
-- [x] MyAnimeList Id scraper
+- [x] MyAnimeList ID resolution
+- [x] AllAnime ID resolution
 - [ ] VLC support
 - [ ] Create packages for Windows, Linux and Termux
 - [ ] Test it on Android termux and Mac

--- a/ani-skip
+++ b/ani-skip
@@ -20,24 +20,29 @@ help_info() {
 
     Options:
       -q, --query
-        Search query or MyAnimeList ID
+        Search query for anime title
+      -i, --id
+        Direct source ID (MyAnimeList or AllAnime ID)
       -e, --episode
         Specify the episode number
-      -s, --title-source
-        Source to search for MAL ID (myanimelist, allanime). Default: myanimelist
-      -f, --title-filter
-        Regex to filter search results for disambiguation
+      -s, --source
+        Source for ID/query resolution (myanimelist, allanime). Default: myanimelist
+      -f, --filter
+        Regex to filter search results for disambiguation (used with -q)
       -V, --version
         Show the version of the script
       -h, --help
         Show this help message and exit
       -U, --update
         Update the script
+
+    Either -q or -i is required.
+
     Some example usages:
-      %s -q \"Solo Leveling\" # Returns MyAnimeList ID
-      %s -q \"Solo Leveling\" -e 3 # Returns MPV skip flag
-      %s -q 52299 -e 5 # Returns MPV skip flag
-      %s -q \"one piece\" -s allanime -f \"^1P$\" -e 12 # AllAnime source with exact match
+      %s -i 52299 -e 5 # MAL ID directly
+      %s -i \"ReooPAxPMsHM4KPMY\" -s allanime -e 12 # AllAnime ID directly
+      %s -q \"Solo Leveling\" -e 3 # Search MAL (default)
+      %s -q \"one piece\" -s allanime -f \"^1P$\" -e 12 # Search AllAnime with filter
       %s -q \"Solo Leveling\" -s allanime -f \"Season 2\" -e 1 # Season disambiguation
     \n" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}"
     exit 0
@@ -71,8 +76,8 @@ fetch_mal_id_myanimelist() {
     fzf_nth=$(printf "%s," $(seq 1 "$(printf "%s" "$name" | wc -w)") | sed 's|,$||')
     results=$(printf "%s" "$mal_metadata" | sed 's|},{|\n|g' | sed 's|.*,"name":"||g ; s|","url":".*||g')
     relevant_name=""
-    if [ -n "$title_filter" ]; then
-        relevant_name=$(printf "%s" "$results" | grep -E "$title_filter" | head -n1)
+    if [ -n "$filter" ]; then
+        relevant_name=$(printf "%s" "$results" | grep -E "$filter" | head -n1)
     fi
     if [ -z "$relevant_name" ]; then
         relevant_name=$(printf "%s" "$results" | fzf -i --filter="$name" --nth="$fzf_nth" | head -n1)
@@ -103,8 +108,8 @@ fetch_mal_id_allanime() {
     [ -z "$pairs" ] && die "No results found on AllAnime!"
 
     names=$(printf "%s" "$pairs" | cut -f2)
-    if [ -n "$title_filter" ]; then
-        relevant_name=$(printf "%s" "$names" | grep -E "$title_filter" | head -n1)
+    if [ -n "$filter" ]; then
+        relevant_name=$(printf "%s" "$names" | grep -E "$filter" | head -n1)
     fi
     if [ -z "$relevant_name" ]; then
         name=$(printf "%s" "$keyword" | tr -cs '[:print:]' ' ' | tr -c '[:alnum:]' ' ')
@@ -118,11 +123,19 @@ fetch_mal_id_allanime() {
     allanime_id=$(printf "%s" "$matched" | cut -f1)
     [ -z "$allanime_id" ] && die "Could not match anime on AllAnime!"
 
-    # Fetch malId using AllAnime show _id
+    resolve_id_allanime "$allanime_id"
+}
+
+resolve_id_allanime() {
+    #shellcheck disable=SC2016
+    : '
+    `resolve_id_allanime` fetches MyAnimeList Identifier using AllAnime show ID
+    :param $1: AllAnime show _id
+    '
     curl -s "$allanime_api" \
         -H "User-Agent: $agent" \
         -H "Content-Type: application/json" \
-        --data-raw "{\"query\":\"{ show(_id: \\\"$allanime_id\\\") { malId } }\"}" \
+        --data-raw "{\"query\":\"{ show(_id: \\\"$1\\\") { malId } }\"}" \
         | sed -n 's/.*"malId":"\([0-9]*\)".*/\1/p'
 }
 
@@ -186,8 +199,8 @@ build_flags() {
     [ -n "$options" ] && printf -- "--chapters-file=%s --script-opts=%s" "$chapters_file" "$options"
 }
 
-title_source="myanimelist"
-title_filter=""
+source="myanimelist"
+filter=""
 
 [ $# -eq 0 ] && help_info
 while [ $# -gt 0 ]; do
@@ -197,8 +210,13 @@ while [ $# -gt 0 ]; do
         -V | --version) printf "%s\n" "$version_number" && exit 0 ;;
         -h | --help) help_info ;;
         -q | --query)
-            [ $# -lt 2 ] && die "missing search query/MyAnimeList ID!"
+            [ $# -lt 2 ] && die "missing search query!"
             query=$2
+            shift
+            ;;
+        -i | --id)
+            [ $# -lt 2 ] && die "missing source ID!"
+            source_id=$2
             shift
             ;;
         -e | --episode)
@@ -209,29 +227,40 @@ while [ $# -gt 0 ]; do
             esac
             shift
             ;;
-        -s | --title-source)
-            [ $# -lt 2 ] && die "missing title source!"
+        -s | --source)
+            [ $# -lt 2 ] && die "missing source!"
             case $2 in
-                myanimelist|allanime) title_source=$2 ;;
+                myanimelist|allanime) source=$2 ;;
                 *) die "invalid title source '$2'! Use: myanimelist, allanime" ;;
             esac
             shift
             ;;
-        -f | --title-filter)
-            [ $# -lt 2 ] && die "missing title filter!"
-            title_filter=$2
+        -f | --filter)
+            [ $# -lt 2 ] && die "missing filter!"
+            filter=$2
             shift
             ;;
     esac
     shift
 done
 
-# Resolve query to MAL ID
-case "$query" in
-    '') die "-q/--query is required!" ;;
-    *[!0-9]*) mal_id=$(fetch_mal_id_"$title_source" $query) ;;
-    *) mal_id=$query ;;
-esac
+# Resolve to MAL ID
+if [ -n "$source_id" ]; then
+    case "$source" in
+        allanime) mal_id=$(resolve_id_allanime "$source_id") ;;
+        myanimelist) mal_id=$source_id ;;
+    esac
+elif [ -n "$query" ]; then
+    case "$query" in
+        *[!0-9]*) mal_id=$(fetch_mal_id_"$source" $query) ;;
+        *)
+            printf "\033[1;33mWarning: passing MAL ID via -q is deprecated, use -i instead\033[0m\n" >&2
+            mal_id=$query
+            ;;
+    esac
+else
+    die "-q/--query or -i/--id is required!"
+fi
 
 [ -z "$mal_id" ] && die "Could not find MAL ID!"
 if [ -z "$episode" ]; then

--- a/ani-skip
+++ b/ani-skip
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-
-version_number="1.0.1"
+version_number="1.1.0"
 
 agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:109.0) Gecko/20100101 Firefox/109.0"
+allanime_api="https://api.allanime.day/api"
 
 chapter_format="\n[CHAPTER]\nTIMEBASE=1/1000\nSTART=%s\nEND=%s\nTITLE=%s\n"
 option_format="skip-%s_start=%s,skip-%s_end=%s" 
@@ -20,9 +20,13 @@ help_info() {
 
     Options:
       -q, --query
-        Anime Title or MyAnimeList ID
+        Search query or MyAnimeList ID
       -e, --episode
         Specify the episode number
+      -s, --title-source
+        Source to search for MAL ID (myanimelist, allanime). Default: myanimelist
+      -f, --title-filter
+        Regex to filter search results for disambiguation
       -V, --version
         Show the version of the script
       -h, --help
@@ -33,7 +37,9 @@ help_info() {
       %s -q \"Solo Leveling\" # Returns MyAnimeList ID
       %s -q \"Solo Leveling\" -e 3 # Returns MPV skip flag
       %s -q 52299 -e 5 # Returns MPV skip flag
-    \n" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" 
+      %s -q \"one piece\" -s allanime -f \"^1P$\" -e 12 # AllAnime source with exact match
+      %s -q \"Solo Leveling\" -s allanime -f \"Season 2\" -e 1 # Season disambiguation
+    \n" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}" "${0##*/}"
     exit 0
 }
 
@@ -52,11 +58,11 @@ update_script() {
     exit 0
 }
 
-fetch_mal_id() {
+fetch_mal_id_myanimelist() {
     #shellcheck disable=SC2016
     : '
-    `fetch_mal_id` fetches MyAnimeList Identifier of particular anime
-    :param $1: title of the anime
+    `fetch_mal_id_myanimelist` fetches MyAnimeList Identifier using MAL search
+    :param $1: search query
     '
     name=$(printf "%s" "$*" | sed 's| (\([0-9]*\) episodes)||')
     keyword=$(printf "%s" "$name" | tr -c '[:alnum:]' ' ' | sed -E 's| |%20|g')
@@ -64,10 +70,60 @@ fetch_mal_id() {
     name=$(printf "%s\n" "$name" | tr -cs '[:print:]' ' ' | tr -c '[:alnum:]' ' ')
     fzf_nth=$(printf "%s," $(seq 1 "$(printf "%s" "$name" | wc -w)") | sed 's|,$||')
     results=$(printf "%s" "$mal_metadata" | sed 's|},{|\n|g' | sed 's|.*,"name":"||g ; s|","url":".*||g')
-    relevant_name=$(printf "%s" "$results" | fzf -i --filter="$name" --nth="$fzf_nth" | head -n1)
-    [ -z "$relevant_name" ] && relevant_name=$(printf "%s" "$results" | fzf -i --filter="$name" | head -n1)
-    [ -z "$relevant_name" ] && relevant_name=$(printf "%s" "$results" | head -n1)
+    relevant_name=""
+    if [ -n "$title_filter" ]; then
+        relevant_name=$(printf "%s" "$results" | grep -E "$title_filter" | head -n1)
+    fi
+    if [ -z "$relevant_name" ]; then
+        relevant_name=$(printf "%s" "$results" | fzf -i --filter="$name" --nth="$fzf_nth" | head -n1)
+        [ -z "$relevant_name" ] && relevant_name=$(printf "%s" "$results" | fzf -i --filter="$name" | head -n1)
+        [ -z "$relevant_name" ] && relevant_name=$(printf "%s" "$results" | head -n1)
+    fi
     printf "%s" "$mal_metadata" | sed 's|},{|\n|g' | grep 'name":"'"$relevant_name"'","url":' | sed -nE 's|.*"id":([0-9]{1,9}),.*|\1|p'
+}
+
+fetch_mal_id_allanime() {
+    #shellcheck disable=SC2016
+    : '
+    `fetch_mal_id_allanime` fetches MyAnimeList Identifier using AllAnime
+    :param $1: search query
+    '
+    search_query='query($search:SearchInput $limit:Int $page:Int $translationType:VaildTranslationTypeEnumType $countryOrigin:VaildCountryOriginEnumType){shows(search:$search limit:$limit page:$page translationType:$translationType countryOrigin:$countryOrigin){edges{_id name}}}'
+    keyword=$(printf "%s" "$*" | sed 's| (\([0-9]*\) episodes)||')
+    variables="{\"search\":{\"query\":\"$keyword\"},\"limit\":10,\"page\":1,\"translationType\":\"sub\",\"countryOrigin\":\"ALL\"}"
+
+    search_result=$(curl -s "$allanime_api" \
+        -H "User-Agent: $agent" \
+        -H "Content-Type: application/json" \
+        --data-raw "{\"query\":\"$search_query\",\"variables\":$variables}")
+
+    # Extract _id and name pairs (one per line: _id\tname)
+    pairs=$(printf "%s" "$search_result" | sed 's|},{|\n|g' | sed -nE 's|.*"_id":"([^"]+)","name":"([^"]+)".*|\1\t\2|p')
+
+    [ -z "$pairs" ] && die "No results found on AllAnime!"
+
+    names=$(printf "%s" "$pairs" | cut -f2)
+    if [ -n "$title_filter" ]; then
+        relevant_name=$(printf "%s" "$names" | grep -E "$title_filter" | head -n1)
+    fi
+    if [ -z "$relevant_name" ]; then
+        name=$(printf "%s" "$keyword" | tr -cs '[:print:]' ' ' | tr -c '[:alnum:]' ' ')
+        relevant_name=$(printf "%s" "$names" | fzf -i --filter="$name" | head -n1)
+        [ -z "$relevant_name" ] && relevant_name=$(printf "%s" "$names" | head -n1)
+    fi
+    matched=$(printf "%s" "$pairs" | awk -F'\t' -v name="$relevant_name" '$2 == name' | head -n1)
+    # Fall back to substring match if exact match fails
+    [ -z "$matched" ] && matched=$(printf "%s" "$pairs" | grep "$relevant_name" | head -n1)
+
+    allanime_id=$(printf "%s" "$matched" | cut -f1)
+    [ -z "$allanime_id" ] && die "Could not match anime on AllAnime!"
+
+    # Fetch malId using AllAnime show _id
+    curl -s "$allanime_api" \
+        -H "User-Agent: $agent" \
+        -H "Content-Type: application/json" \
+        --data-raw "{\"query\":\"{ show(_id: \\\"$allanime_id\\\") { malId } }\"}" \
+        | sed -n 's/.*"malId":"\([0-9]*\)".*/\1/p'
 }
 
 ftoi() {
@@ -130,6 +186,8 @@ build_flags() {
     [ -n "$options" ] && printf -- "--chapters-file=%s --script-opts=%s" "$chapters_file" "$options"
 }
 
+title_source="myanimelist"
+title_filter=""
 
 [ $# -eq 0 ] && help_info
 while [ $# -gt 0 ]; do
@@ -139,11 +197,8 @@ while [ $# -gt 0 ]; do
         -V | --version) printf "%s\n" "$version_number" && exit 0 ;;
         -h | --help) help_info ;;
         -q | --query)
-            [ $# -lt 2 ] && die "missing anime title/MyAnimeList ID!"
-            case $2 in
-                ''|*[!0-9]*) mal_id=$(fetch_mal_id $2) ;;
-                *) mal_id=$2 ;;
-            esac
+            [ $# -lt 2 ] && die "missing search query/MyAnimeList ID!"
+            query=$2
             shift
             ;;
         -e | --episode)
@@ -152,11 +207,33 @@ while [ $# -gt 0 ]; do
                 ''|*[!0-9]*) die "value must be a number!" ;;
                 *) episode=$2 ;;
             esac
+            shift
+            ;;
+        -s | --title-source)
+            [ $# -lt 2 ] && die "missing title source!"
+            case $2 in
+                myanimelist|allanime) title_source=$2 ;;
+                *) die "invalid title source '$2'! Use: myanimelist, allanime" ;;
+            esac
+            shift
+            ;;
+        -f | --title-filter)
+            [ $# -lt 2 ] && die "missing title filter!"
+            title_filter=$2
+            shift
+            ;;
     esac
     shift
 done
 
-[ -z "$mal_id" ] && die "-q/--query is required!"
+# Resolve query to MAL ID
+case "$query" in
+    '') die "-q/--query is required!" ;;
+    *[!0-9]*) mal_id=$(fetch_mal_id_"$title_source" $query) ;;
+    *) mal_id=$query ;;
+esac
+
+[ -z "$mal_id" ] && die "Could not find MAL ID!"
 if [ -z "$episode" ]; then
     printf "%s" "$mal_id"
 else


### PR DESCRIPTION
## Summary

- Add `-i/--id` flag for passing source IDs directly (AllAnime ID or MAL ID)
- Add `-s/--source` flag to choose between `myanimelist` (default) and `allanime` for ID/query resolution
- Add `-f/--filter` flag that accepts a regex to filter/disambiguate search results (e.g. `^1P$` for exact match, `Season 2` for season disambiguation)
- Deprecate passing numeric MAL IDs via `-q` (still works, prints warning)
- AllAnime stores `malId` per show, so querying it directly bypasses the fragile MAL prefix search + fzf fuzzy matching

## Problem

ani-cli uses AllAnime as its source, which returns display names like "1P" for One Piece. When passed to ani-skip, the MAL prefix search can't resolve these to the correct MAL ID, resulting in "Skip times not found!" (Issue #14). Similarly, multi-season anime can't be disambiguated (Issue #19).

## Solution

### Direct ID path (ideal for ani-cli)
ani-cli already has the AllAnime `_id` for the selected show. Pass it directly:
```bash
ani-skip -i "ReooPAxPMsHM4KPMY" -s allanime -e 12
```

### Search path (standalone users)
```bash
# Search AllAnime with filter for disambiguation
ani-skip -q "one piece" -s allanime -f "^1P$" -e 12

# Season disambiguation
ani-skip -q "Solo Leveling" -s allanime -f "Season 2" -e 1

# Default MAL search (backwards compatible)
ani-skip -q "Solo Leveling" -e 3
```

## Corresponding ani-cli change

A one-line change in ani-cli:
```bash
# Before
mal_id="$(ani-skip -q "${skip_title:-${title}}")"

# After
mal_id="$(ani-skip -i "${id}" -s allanime)"
```