### PR TITLE
feat: skip behavior controls and lua script auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ ani-skip -h
       --toggle
         Enable keybind in mpv to toggle skipping on/off 
         [default: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
+      --offset <seconds>
+        End skip N seconds early to avoid missing episode content
+        [max: 5, default: 0]
       -V, --version
         Show the version of the script
       -h, --help
@@ -114,10 +117,11 @@ ani-skip -i 52299 -e 5
 
 ### Skip behavior
 
-By default, openings and endings are skipped once — you can seek back to watch them again. Use `--always` to skip every time, and `--toggle` to enable the `a` keybind in mpv for toggling skipping on/off. Set `ANI_SKIP_TOGGLE_KEY` to customize the keybind.
+By default, openings and endings are skipped once — you can seek back to watch them again. Use `--always` to skip every time, `--toggle` to enable the `a` keybind in mpv for toggling skipping on/off, and `--offset` to end the skip a few seconds early. Set `ANI_SKIP_TOGGLE_KEY` to customize the keybind.
 
 ```sh
-ani-skip -i 52299 -e 3 --always --toggle
+# Skip always, with toggle keybind, ending skip 3 seconds early
+ani-skip -i 52299 -e 3 --always --toggle --offset 3
 ```
 
 ### Fetch MAL ID only (no episode)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ani-skip -h
       --toggle
         Enable keybind in mpv to toggle skipping on/off 
         [default: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
-      --offset <seconds>
+      -o, --offset <seconds>
         End skip N seconds early to avoid missing episode content
         [max: 5, default: 0]
       -V, --version

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ani-skip -h
       --toggle
         Enable keybind in mpv to toggle skipping on/off.
         When enabled, skips always while active (default: skip once).
-        [default key: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
+        [default key: 'T' (shift+t), set ANI_SKIP_TOGGLE_KEY to customize]
       -o, --offset <seconds>
         End skip N seconds early to avoid missing episode content
         [max: 5, default: 0]
@@ -115,7 +115,7 @@ ani-skip -i 52299 -e 5
 
 ### Skip behavior
 
-By default, openings and endings are skipped once — you can seek back to watch them again. Use `--toggle` to enable the `a` keybind in mpv for toggling skipping on/off (skips always while active). Use `--offset` to end the skip a few seconds early. Set `ANI_SKIP_TOGGLE_KEY` to customize the keybind.
+By default, openings and endings are skipped once — you can seek back to watch them again. Use `--toggle` to enable the `T` (shift+t) keybind in mpv for toggling skipping on/off (skips always while active). Use `--offset` to end the skip a few seconds early. Set `ANI_SKIP_TOGGLE_KEY` to customize the keybind.
 
 ```sh
 # Toggle keybind enabled, ending skip 3 seconds early

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ ani-skip -h
       -h, --help
         Show this help message and exit
       -U, --update
-        Update the script
+        Update to the latest version
 
     Either -q or -i is required.
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,10 @@ ani-skip -h
         [default: myanimelist]
       -f, --filter
         Regex to filter search results for disambiguation (used with -q)
-      --always
-        Always skip 
-        [default: skip once per session]
       --toggle
-        Enable keybind in mpv to toggle skipping on/off 
-        [default: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
+        Enable keybind in mpv to toggle skipping on/off.
+        When enabled, skips always while active (default: skip once).
+        [default key: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
       -o, --offset <seconds>
         End skip N seconds early to avoid missing episode content
         [max: 5, default: 0]
@@ -117,11 +115,11 @@ ani-skip -i 52299 -e 5
 
 ### Skip behavior
 
-By default, openings and endings are skipped once — you can seek back to watch them again. Use `--always` to skip every time, `--toggle` to enable the `a` keybind in mpv for toggling skipping on/off, and `--offset` to end the skip a few seconds early. Set `ANI_SKIP_TOGGLE_KEY` to customize the keybind.
+By default, openings and endings are skipped once — you can seek back to watch them again. Use `--toggle` to enable the `a` keybind in mpv for toggling skipping on/off (skips always while active). Use `--offset` to end the skip a few seconds early. Set `ANI_SKIP_TOGGLE_KEY` to customize the keybind.
 
 ```sh
-# Skip always, with toggle keybind, ending skip 3 seconds early
-ani-skip -i 52299 -e 3 --always --toggle --offset 3
+# Toggle keybind enabled, ending skip 3 seconds early
+ani-skip -i 52299 -e 3 --toggle -o 3
 ```
 
 ### Fetch MAL ID only (no episode)

--- a/README.md
+++ b/README.md
@@ -54,9 +54,16 @@ ani-skip -h
       -e, --episode
         Specify the episode number
       -s, --source
-        Source for ID/query resolution (myanimelist, allanime). Default: myanimelist
+        Source for ID/query resolution (myanimelist, allanime). 
+        [default: myanimelist]
       -f, --filter
         Regex to filter search results for disambiguation (used with -q)
+      --always
+        Always skip 
+        [default: skip once per session]
+      --toggle
+        Enable keybind in mpv to toggle skipping on/off 
+        [default: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
       -V, --version
         Show the version of the script
       -h, --help
@@ -103,6 +110,14 @@ ani-skip -i "ReooPAxPMsHM4KPMY" -s allanime -e 12
 
 # MAL ID
 ani-skip -i 52299 -e 5
+```
+
+### Skip behavior
+
+By default, openings and endings are skipped once — you can seek back to watch them again. Use `--always` to skip every time, and `--toggle` to enable the `a` keybind in mpv for toggling skipping on/off. Set `ANI_SKIP_TOGGLE_KEY` to customize the keybind.
+
+```sh
+ani-skip -i 52299 -e 3 --always --toggle
 ```
 
 ### Fetch MAL ID only (no episode)

--- a/ani-skip
+++ b/ani-skip
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version_number="1.1.0"
+version_number="1.2.0"
 
 agent="Mozilla/5.0 (Windows NT 6.1; Win64; rv:109.0) Gecko/20100101 Firefox/109.0"
 allanime_api="https://api.allanime.day/api"

--- a/ani-skip
+++ b/ani-skip
@@ -44,7 +44,7 @@ help_info() {
       -h, --help
         Show this help message and exit
       -U, --update
-        Update the script
+        Update to the latest version
 
     Either -q or -i is required.
 
@@ -70,6 +70,23 @@ update_script() {
             die "Can't update for some reason!"
         fi
     fi
+
+    lua_remote="$(curl -s -A "$agent" "https://raw.githubusercontent.com/synacktraa/ani-skip/master/skip.lua")" || die "Connection error"
+    for lua_path in \
+        "${HOME}/.config/mpv/scripts/skip.lua" \
+        "${HOME}/scoop/apps/mpv/current/portable_config/scripts/skip.lua"; do
+        [ -f "$lua_path" ] || continue
+        lua_update="$(printf '%s\n' "$lua_remote" | diff -u "$lua_path" -)"
+        if [ -z "$lua_update" ]; then
+            printf "skip.lua (%s) is up to date :)\n" "$lua_path"
+        else
+            if printf '%s\n' "$lua_update" | patch "$lua_path" -; then
+                printf "skip.lua (%s) has been updated\n" "$lua_path"
+            else
+                printf "\033[1;33mWarning: Could not update skip.lua at %s\033[0m\n" "$lua_path" >&2
+            fi
+        fi
+    done
     exit 0
 }
 

--- a/ani-skip
+++ b/ani-skip
@@ -223,8 +223,8 @@ build_flags() {
 
     printf "%s" ";FFMETADATA1" > "$chapters_file"
     options=$(build_options "$metadata")
-    [ "$always" = 1 ] && options="$options,skip-always=true"
-    [ "$toggle" = 1 ] && options="$options,skip-toggle=true,skip-toggle_key=$toggle_key"
+    [ "$always" = 1 ] && options="$options,skip-always=yes"
+    [ "$toggle" = 1 ] && options="$options,skip-toggle=yes,skip-toggle_key=$toggle_key"
     [ "$offset" -gt 0 ] && options="$options,skip-offset=$offset"
     [ -n "$options" ] && printf -- "--chapters-file=%s --script-opts=%s" "$chapters_file" "$options"
 }

--- a/ani-skip
+++ b/ani-skip
@@ -69,15 +69,18 @@ update_script() {
         fi
     fi
 
-    lua_remote="$(curl -s -A "$agent" "https://raw.githubusercontent.com/synacktraa/ani-skip/master/skip.lua")" || die "Connection error"
-    win_home=""
-    if [ -n "$WSL_DISTRO_NAME" ]; then
-        win_home="$(wslpath "$(cmd.exe /c "<nul set /p=%UserProfile%" 2>/dev/null)")"
+    # Resolve real user home when run with sudo
+    if [ -n "$SUDO_USER" ]; then
+        real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+    else
+        real_home="$HOME"
     fi
+
+    lua_remote="$(curl -s -A "$agent" "https://raw.githubusercontent.com/synacktraa/ani-skip/master/skip.lua")" || die "Connection error"
     for lua_path in \
-        "${HOME}/.config/mpv/scripts/skip.lua" \
-        "${HOME}/scoop/apps/mpv/current/portable_config/scripts/skip.lua" \
-        ${win_home:+"${win_home}/scoop/apps/mpv/current/portable_config/scripts/skip.lua"}; do
+        "${real_home}/.config/mpv/scripts/skip.lua" \
+        "${real_home}/scoop/apps/mpv/current/portable_config/scripts/skip.lua" \
+        /mnt/c/Users/*/scoop/apps/mpv/current/portable_config/scripts/skip.lua; do
         [ -f "$lua_path" ] || continue
         lua_update="$(printf '%s\n' "$lua_remote" | diff -u "$lua_path" -)"
         if [ -z "$lua_update" ]; then
@@ -90,6 +93,7 @@ update_script() {
             fi
         fi
     done
+
     exit 0
 }
 

--- a/ani-skip
+++ b/ani-skip
@@ -26,9 +26,16 @@ help_info() {
       -e, --episode
         Specify the episode number
       -s, --source
-        Source for ID/query resolution (myanimelist, allanime). Default: myanimelist
+        Source for ID/query resolution (myanimelist, allanime). 
+        [default: myanimelist]
       -f, --filter
         Regex to filter search results for disambiguation (used with -q)
+      --always
+        Always skip 
+        [default: skip once per session]
+      --toggle
+        Enable keybind in mpv to toggle skipping on/off 
+        [default: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
       -V, --version
         Show the version of the script
       -h, --help
@@ -196,11 +203,16 @@ build_flags() {
 
     printf "%s" ";FFMETADATA1" > "$chapters_file"
     options=$(build_options "$metadata")
+    [ "$always" = 1 ] && options="$options,skip-always=true"
+    [ "$toggle" = 1 ] && options="$options,skip-toggle=true,skip-toggle_key=$toggle_key"
     [ -n "$options" ] && printf -- "--chapters-file=%s --script-opts=%s" "$chapters_file" "$options"
 }
 
 source="myanimelist"
 filter=""
+always=0
+toggle=0
+toggle_key="${ANI_SKIP_TOGGLE_KEY:-a}"
 
 [ $# -eq 0 ] && help_info
 while [ $# -gt 0 ]; do
@@ -240,6 +252,8 @@ while [ $# -gt 0 ]; do
             filter=$2
             shift
             ;;
+        --always) always=1 ;;
+        --toggle) toggle=1 ;;
     esac
     shift
 done

--- a/ani-skip
+++ b/ani-skip
@@ -30,12 +30,10 @@ help_info() {
         [default: myanimelist]
       -f, --filter
         Regex to filter search results for disambiguation (used with -q)
-      --always
-        Always skip 
-        [default: skip once per session]
       --toggle
-        Enable keybind in mpv to toggle skipping on/off
-        [default: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
+        Enable keybind in mpv to toggle skipping on/off.
+        When enabled, skips always while active (default: skip once).
+        [default key: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
       -o, --offset <seconds>
         End skip N seconds early to avoid missing episode content
         [max: 5, default: 0]
@@ -223,7 +221,6 @@ build_flags() {
 
     printf "%s" ";FFMETADATA1" > "$chapters_file"
     options=$(build_options "$metadata")
-    [ "$always" = 1 ] && options="$options,skip-always=yes"
     [ "$toggle" = 1 ] && options="$options,skip-toggle=yes,skip-toggle_key=$toggle_key"
     [ "$offset" -gt 0 ] && options="$options,skip-offset=$offset"
     [ -n "$options" ] && printf -- "--chapters-file=%s --script-opts=%s" "$chapters_file" "$options"
@@ -231,7 +228,6 @@ build_flags() {
 
 source="myanimelist"
 filter=""
-always=0
 toggle=0
 toggle_key="${ANI_SKIP_TOGGLE_KEY:-a}"
 offset=0
@@ -274,7 +270,6 @@ while [ $# -gt 0 ]; do
             filter=$2
             shift
             ;;
-        --always) always=1 ;;
         --toggle) toggle=1 ;;
         -o | --offset)
             [ $# -lt 2 ] && die "missing offset value!"

--- a/ani-skip
+++ b/ani-skip
@@ -33,7 +33,7 @@ help_info() {
       --toggle
         Enable keybind in mpv to toggle skipping on/off.
         When enabled, skips always while active (default: skip once).
-        [default key: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
+        [default key: 'T' (shift+t), set ANI_SKIP_TOGGLE_KEY to customize]
       -o, --offset <seconds>
         End skip N seconds early to avoid missing episode content
         [max: 5, default: 0]
@@ -229,7 +229,7 @@ build_flags() {
 source="myanimelist"
 filter=""
 toggle=0
-toggle_key="${ANI_SKIP_TOGGLE_KEY:-a}"
+toggle_key="${ANI_SKIP_TOGGLE_KEY:-T}"
 offset=0
 
 [ $# -eq 0 ] && help_info

--- a/ani-skip
+++ b/ani-skip
@@ -34,8 +34,11 @@ help_info() {
         Always skip 
         [default: skip once per session]
       --toggle
-        Enable keybind in mpv to toggle skipping on/off 
+        Enable keybind in mpv to toggle skipping on/off
         [default: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
+      --offset <seconds>
+        End skip N seconds early to avoid missing episode content
+        [max: 5, default: 0]
       -V, --version
         Show the version of the script
       -h, --help
@@ -205,6 +208,7 @@ build_flags() {
     options=$(build_options "$metadata")
     [ "$always" = 1 ] && options="$options,skip-always=true"
     [ "$toggle" = 1 ] && options="$options,skip-toggle=true,skip-toggle_key=$toggle_key"
+    [ "$offset" -gt 0 ] && options="$options,skip-offset=$offset"
     [ -n "$options" ] && printf -- "--chapters-file=%s --script-opts=%s" "$chapters_file" "$options"
 }
 
@@ -213,6 +217,7 @@ filter=""
 always=0
 toggle=0
 toggle_key="${ANI_SKIP_TOGGLE_KEY:-a}"
+offset=0
 
 [ $# -eq 0 ] && help_info
 while [ $# -gt 0 ]; do
@@ -254,6 +259,14 @@ while [ $# -gt 0 ]; do
             ;;
         --always) always=1 ;;
         --toggle) toggle=1 ;;
+        --offset)
+            [ $# -lt 2 ] && die "missing offset value!"
+            case $2 in
+                ''|*[!0-9]*) die "offset must be a number!" ;;
+                *) [ "$2" -gt 5 ] && die "offset cannot be more than 5 seconds!" ; offset=$2 ;;
+            esac
+            shift
+            ;;
     esac
     shift
 done

--- a/ani-skip
+++ b/ani-skip
@@ -36,7 +36,7 @@ help_info() {
       --toggle
         Enable keybind in mpv to toggle skipping on/off
         [default: 'a', set ANI_SKIP_TOGGLE_KEY to customize]
-      --offset <seconds>
+      -o, --offset <seconds>
         End skip N seconds early to avoid missing episode content
         [max: 5, default: 0]
       -V, --version
@@ -259,7 +259,7 @@ while [ $# -gt 0 ]; do
             ;;
         --always) always=1 ;;
         --toggle) toggle=1 ;;
-        --offset)
+        -o | --offset)
             [ $# -lt 2 ] && die "missing offset value!"
             case $2 in
                 ''|*[!0-9]*) die "offset must be a number!" ;;

--- a/ani-skip
+++ b/ani-skip
@@ -70,9 +70,14 @@ update_script() {
     fi
 
     lua_remote="$(curl -s -A "$agent" "https://raw.githubusercontent.com/synacktraa/ani-skip/master/skip.lua")" || die "Connection error"
+    win_home=""
+    if [ -n "$WSL_DISTRO_NAME" ]; then
+        win_home="$(wslpath "$(cmd.exe /c "<nul set /p=%UserProfile%" 2>/dev/null)")"
+    fi
     for lua_path in \
         "${HOME}/.config/mpv/scripts/skip.lua" \
-        "${HOME}/scoop/apps/mpv/current/portable_config/scripts/skip.lua"; do
+        "${HOME}/scoop/apps/mpv/current/portable_config/scripts/skip.lua" \
+        ${win_home:+"${win_home}/scoop/apps/mpv/current/portable_config/scripts/skip.lua"}; do
         [ -f "$lua_path" ] || continue
         lua_update="$(printf '%s\n' "$lua_remote" | diff -u "$lua_path" -)"
         if [ -z "$lua_update" ]; then

--- a/skip.lua
+++ b/skip.lua
@@ -4,7 +4,7 @@ local mpv_options = require("mp.options")
 
 local options = { -- setting default options
     op_start = 0, op_end = 0, ed_start = 0, ed_end = 0,
-    always = false, toggle = false, toggle_key = "a",
+    always = false, toggle = false, toggle_key = "a", offset = 0,
 }
 mpv_options.read_options(options, "skip") --reading script-opts data
 
@@ -27,7 +27,7 @@ local function skip()
     -- Check for opening sequence
     if current_time >= options.op_start and current_time < options.op_end then
         if options.always or not skipped_op then
-            mp.set_property_number("time-pos", options.op_end)
+            mp.set_property_number("time-pos", options.op_end - options.offset)
             skipped_op = true
         end
     end
@@ -35,7 +35,7 @@ local function skip()
     -- Check for ending sequence
     if current_time >= options.ed_start and current_time < options.ed_end then
         if options.always or not skipped_ed then
-            mp.set_property_number("time-pos", options.ed_end)
+            mp.set_property_number("time-pos", options.ed_end - options.offset)
             skipped_ed = true
         end
     end

--- a/skip.lua
+++ b/skip.lua
@@ -4,26 +4,51 @@ local mpv_options = require("mp.options")
 
 local options = { -- setting default options
     op_start = 0, op_end = 0, ed_start = 0, ed_end = 0,
+    always = false, toggle = false, toggle_key = "a",
 }
 mpv_options.read_options(options, "skip") --reading script-opts data
 
+local skipped_op = false
+local skipped_ed = false
+local skip_enabled = true
+
 -- Main function to check and skip if within the defined section
 local function skip()
+    if not skip_enabled then
+        return
+    end
+
     local current_time = mp.get_property_number("time-pos")
-    
+
     if not current_time then
         return
     end
 
     -- Check for opening sequence
     if current_time >= options.op_start and current_time < options.op_end then
-        mp.set_property_number("time-pos", options.op_end)
+        if options.always or not skipped_op then
+            mp.set_property_number("time-pos", options.op_end)
+            skipped_op = true
+        end
     end
-    
+
     -- Check for ending sequence
     if current_time >= options.ed_start and current_time < options.ed_end then
-        mp.set_property_number("time-pos", options.ed_end)
+        if options.always or not skipped_ed then
+            mp.set_property_number("time-pos", options.ed_end)
+            skipped_ed = true
+        end
     end
+end
+
+-- Toggle skip on/off
+local function toggle_skip()
+    skip_enabled = not skip_enabled
+    mp.osd_message("Skip: " .. (skip_enabled and "ON" or "OFF"), 2)
+end
+
+if options.toggle then
+    mp.add_key_binding(options.toggle_key, "toggle-skip", toggle_skip)
 end
 
 -- Bind the function to be called whenever the time position is changed

--- a/skip.lua
+++ b/skip.lua
@@ -4,7 +4,7 @@ local mpv_options = require("mp.options")
 
 local options = { -- setting default options
     op_start = 0, op_end = 0, ed_start = 0, ed_end = 0,
-    always = false, toggle = false, toggle_key = "a", offset = 0,
+    toggle = false, toggle_key = "a", offset = 0,
 }
 mpv_options.read_options(options, "skip") --reading script-opts data
 
@@ -24,18 +24,21 @@ local function skip()
         return
     end
 
+    local op_target = options.op_end - options.offset
+    local ed_target = options.ed_end - options.offset
+
     -- Check for opening sequence
-    if current_time >= options.op_start and current_time < options.op_end then
-        if options.always or not skipped_op then
-            mp.set_property_number("time-pos", options.op_end - options.offset)
+    if current_time >= options.op_start and current_time < op_target then
+        if options.toggle or not skipped_op then
+            mp.set_property_number("time-pos", op_target)
             skipped_op = true
         end
     end
 
     -- Check for ending sequence
-    if current_time >= options.ed_start and current_time < options.ed_end then
-        if options.always or not skipped_ed then
-            mp.set_property_number("time-pos", options.ed_end - options.offset)
+    if current_time >= options.ed_start and current_time < ed_target then
+        if options.toggle or not skipped_ed then
+            mp.set_property_number("time-pos", ed_target)
             skipped_ed = true
         end
     end
@@ -44,6 +47,10 @@ end
 -- Toggle skip on/off
 local function toggle_skip()
     skip_enabled = not skip_enabled
+    if skip_enabled then
+        skipped_op = false
+        skipped_ed = false
+    end
     mp.osd_message("Skip: " .. (skip_enabled and "ON" or "OFF"), 2)
 end
 

--- a/skip.lua
+++ b/skip.lua
@@ -4,7 +4,7 @@ local mpv_options = require("mp.options")
 
 local options = { -- setting default options
     op_start = 0, op_end = 0, ed_start = 0, ed_end = 0,
-    toggle = false, toggle_key = "a", offset = 0,
+    toggle = false, toggle_key = "T", offset = 0,
 }
 mpv_options.read_options(options, "skip") --reading script-opts data
 


### PR DESCRIPTION
Changes the default skip behavior from skip always to skip once, adds new flags for user control, and makes `-U` update `skip.lua` alongside the main script.

**Problem:** `skip.lua` unconditionally skips the opening/ending every time the playback position enters those ranges. This means seeking back to watch an opening is impossible — it just skips again immediately.

**Changes:**

- **Skip once (new default):** op/ed are skipped once per session. Seeking back lets you watch them.
- **`--toggle`:** Enables a keybind (default `T` / shift+t, customizable via `ANI_SKIP_TOGGLE_KEY`) to toggle skipping on/off during playback. When enabled, skips always while active. Toggling ON resets skipped state. Shows an OSD message with the current state.
- **`-o/--offset <seconds>`:** End skips N seconds early (max 5) to avoid missing episode content when skip times are slightly off.
- **`-U` now updates `skip.lua`:** Checks known mpv script paths and patches `skip.lua` if found.

All flags can be combined. All changes are backwards compatible — existing setups that don't use the new flags just get the improved skip-once behavior.

**Note for existing users:** Run `ani-skip -U` twice on this release — the first run updates the shell script (which adds the lua update logic), the second run actually updates `skip.lua`.

Closes #15, #8